### PR TITLE
Add eunit_opts support, clean up env setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ mix deps.compile
 mix eunit
 ```
 
+To make the `eunit` task run in the `:test` environment, add the following
+to the `project` section of you mix file:
+
+```elixir
+def project
+  [#... existing project settings,
+   preferred_cli_env: [eunit: :test]
+  ]
+end
+```
 
 Command line options:
 ---------------------


### PR DESCRIPTION
I've added support for externally setting the `eunit_opts` value, as well as renamed it from `eunit_options` for consistency with how it's named in eunit itself.
I also made a couple of minor changes to do with how the environment is set/handled. Explicitly setting it to `:test` in `run()` was not enough to cause a test-specific config to be read. The step I added to the readme, however, will do this.
