### PR TITLE
Better output and other QoL improvements

### DIFF
--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -50,10 +50,11 @@ defmodule Mix.Tasks.Eunit do
 
     # run the actual tests
     if(options[:cover], do: cover_start())
-    test_modules(post_config[:erlc_paths], options[:patterns])
-    |> Enum.map(&module_name_from_path/1)
-    |> Enum.drop_while(fn(m) ->
-      tests_pass?(m, options[:eunit_opts] ++ post_config[:eunit_opts]) end)
+    modules =
+      test_modules(post_config[:erlc_paths], options[:patterns])
+      |> Enum.map(&module_name_from_path/1)
+      |> Enum.map(fn m -> {:module, m} end)
+    :eunit.test(modules, options[:eunit_opts] ++ post_config[:eunit_opts])
     if(options[:cover], do: cover_analyse())
   end
 
@@ -145,11 +146,6 @@ defmodule Mix.Tasks.Eunit do
     module_name
     |> String.replace(~r/_tests$/, "")
     |> String.to_atom
-  end
-
-  defp tests_pass?(module, eunit_opts) do
-    IO.puts("Running eunit tests in #{module}:")
-    :ok == :eunit.test(module, eunit_opts)
   end
 
   defp cover_start() do

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -55,7 +55,8 @@ defmodule Mix.Tasks.Eunit do
       |> Enum.map(&module_name_from_path/1)
       |> Enum.map(fn m -> {:module, m} end)
 
-    case :eunit.test(modules, options[:eunit_opts] ++ post_config[:eunit_opts]) do
+    eunit_opts = get_eunit_opts(options, post_config)
+    case :eunit.test(modules, eunit_opts) do
       :error -> Mix.raise "mix eunit failed"
       :ok -> :ok
     end
@@ -68,8 +69,11 @@ defmodule Mix.Tasks.Eunit do
      argv,
      _errors} = OptionParser.parse(args,
                                   switches: [verbose: :boolean,
+                                             profile: :boolean,
+                                             nocolor: :boolean,
                                              cover: :boolean],
                                   aliases: [v: :verbose,
+                                            p: :profile,
                                             c: :cover])
 
     patterns = case argv do
@@ -82,14 +86,38 @@ defmodule Mix.Tasks.Eunit do
                    _ -> []
                  end
 
-    %{eunit_opts: eunit_opts, patterns: patterns, cover: switches[:cover]}
+    %{eunit_opts: eunit_opts,
+      patterns: patterns,
+      profile: switches[:profile],
+      nocolor: switches[:nocolor],
+      cover: switches[:cover]}
   end
 
   defp eunit_post_config(existing_config) do
     [erlc_paths: existing_config[:erlc_paths] ++ ["test"],
      erlc_options: existing_config[:erlc_options] ++ [{:d, :TEST}],
-     eunit_opts: existing_config[:eunit_opts]]
+     eunit_opts: existing_config[:eunit_opts] || []]
   end
+
+  defp get_eunit_opts(options, post_config) do
+    eunit_opts = options[:eunit_opts] ++ post_config[:eunit_opts]
+    maybe_add_formatter(eunit_opts, options[:profile], options[:nocolor])
+  end
+
+  defp maybe_add_formatter(opts, profile, nocolor) do
+    if List.keymember?(opts, :report, 0) do
+      opts
+    else
+      format_opts = nocolor_opt(nocolor) ++ profile_opt(profile)
+      [:no_tty, {:report, {:eunit_progress, format_opts}} | opts]
+    end
+  end
+
+  defp nocolor_opt(true), do: []
+  defp nocolor_opt(_), do: [:colored]
+
+  defp profile_opt(true), do: [:profile]
+  defp profile_opt(_), do: []
 
   defp modify_project_config(post_config) do
     %{name: name, file: file} = Mix.Project.pop

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -54,7 +54,12 @@ defmodule Mix.Tasks.Eunit do
       test_modules(post_config[:erlc_paths], options[:patterns])
       |> Enum.map(&module_name_from_path/1)
       |> Enum.map(fn m -> {:module, m} end)
-    :eunit.test(modules, options[:eunit_opts] ++ post_config[:eunit_opts])
+
+    case :eunit.test(modules, options[:eunit_opts] ++ post_config[:eunit_opts]) do
+      :error -> Mix.raise "mix eunit failed"
+      :ok -> :ok
+    end
+
     if(options[:cover], do: cover_analyse())
   end
 

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -51,13 +51,17 @@ defmodule Mix.Tasks.Eunit do
     ensure_compile
     Mix.Task.run "compile"
 
-    # Start cover
+    # start cover
     cover =
       if options[:cover] do
         compile_path = Mix.Project.compile_path(project)
         cover = Keyword.merge(@cover, project[:test_coverage] || [])
         cover[:tool].start(compile_path, cover)
       end
+
+    # start the application
+    Mix.shell.print_app
+    Mix.Task.run "app.start", args
 
     # run the actual tests
     modules =

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -25,9 +25,12 @@ defmodule Mix.Tasks.Eunit do
 
   The runner automatically adds \".erl\" to the patterns.
 
-  The following command line switch is also available:
+  The following command line switches are also available:
 
-  * --verbose/-v - Run eunit with the :verbose option.
+  * `--verbose`, `-v`   - Run eunit with the :verbose option.
+  * `--cover`, `-c`     - Create a coverage report after running the tests.
+  * `--profile`, `-p`   - Show a list of the 10 slowest tests.
+  * `--nocolor`         - Disable color output.
 
   Test search path:
   -----------------

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -86,24 +86,9 @@ defmodule Mix.Tasks.Eunit do
   end
 
   defp modify_project_config(post_config) do
-    # note - we have to grab build_path because
-    # Mix.Project.push resets the build path
-    build_path = Mix.Project.build_path
-    |> Path.split
-    |> Enum.map(fn(p) -> filter_replace(p, "dev", "eunit") end)
-    |> Path.join
-
     %{name: name, file: file} = Mix.Project.pop
-    Mix.ProjectStack.post_config(Keyword.merge(post_config,
-                                               [build_path: build_path]))
+    Mix.ProjectStack.post_config(post_config)
     Mix.Project.push name, file
-  end
-
-  defp filter_replace(x, x, r) do
-    r
-  end
-  defp filter_replace(x, _y, _r) do
-    x
   end
 
   defp ensure_compile do

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule MixEunit.Mixfile do
      version: "0.2.0",
      elixir: "~> 1.0",
      description: "A mix task to run eunit tests, works for umbrella projects",
+     preferred_cli_env: [eunit: :test],
      package: package,
      deps: deps]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,8 @@ defmodule MixEunit.Mixfile do
      version: "0.2.0",
      elixir: "~> 1.0",
      description: "A mix task to run eunit tests, works for umbrella projects",
-     package: package]
+     package: package,
+     deps: deps]
   end
 
   defp package do
@@ -21,5 +22,9 @@ defmodule MixEunit.Mixfile do
         links: %{"github" => "https://github.com/dantswain/mix_eunit"},
         licenses: ["MIT"]
     ]
+  end
+
+  defp deps do
+    [{:eunit_formatters, "~> 0.3.1", only: :test}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,6 @@ defmodule MixEunit.Mixfile do
   end
 
   defp deps do
-    [{:eunit_formatters, "~> 0.3.1", only: :test}]
+    [{:eunit_formatters, "~> 0.3.1"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,1 @@
+%{"eunit_formatters": {:hex, :eunit_formatters, "0.3.1", "7a6fc351eb5b873e2356b8852eb751e20c13a72fbca03393cf682b8483509573", [:rebar3], []}}


### PR DESCRIPTION
This change includes several improvements intended to make `mix_eunit` more pleasant to use.
- Much nicer output by default.
- Run the tests all at once instead of individually. This gives you a single summary at the end of the test run.
- Test failures cause the task to fail. Useful when this is part of a CI process.
- The application under test is automatically started before the test suite runs.
- Coverage is handled the same way as `ExUnit`. You can use custom coverage tools with the `eunit` task. 
