### PR TITLE
Start the application before running the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,16 @@ The runner automatically adds ".erl" to the patterns.
 
 The following command line switch is also available:
 
-* `--verbose/-v` - Run eunit with the `:verbose` option.
-* `--cover/-c` - Run cover during the tests. See below.
+  * `--verbose`, `-v` - run eunit with the :verbose option
+  * `--cover`, `-c` - create a coverage report after running the tests
+  * `--profile`, `-p` - show a list of the 10 slowest tests
+  * `--start` - start applications after compilation
+  * `--no-color` - disable color output
+  * `--force` - force compilation regardless of compilation times
+  * `--no-compile` - do not compile even if files require compilation
+  * `--no-archives-check` - do not check archives
+  * `--no-deps-check` - do not check dependencies
+  * `--no-elixir-version-check` - do not check Elixir version
 
 Project Settings:
 -----------------
@@ -69,13 +77,22 @@ The following `mix.exs` project settings affect the behavior of `mix eunit`.
 def project
   [
     # existing project settings
-    
+
     # run the `eunit` task in the `:test` environment
     preferred_cli_env: [eunit: :test],
-    
+
     # set the output directory for `mix eunit --cover` reports
     #   the default is `./cover` (same as `mix test --cover`)
     test_coverage: [output: "_build/#{Mix.env}/cover"]
+
+    # set switches that affect every invocation of the eunit task
+    eunit: [
+      verbose: false,
+      cover: true,
+      profile: true,
+      start: true,
+      color: false
+    ]
   ]
 end
 ```
@@ -91,11 +108,6 @@ code.
 
 By default, `mix eunit --cover` produces coverage reports in HTML
 format in the same `cover` directory that `mix test --cover` does.
-The filenames are slightly different - `mix test --cover` produces files with
-names like `my_source_file.html` whereas `mix eunit --cover` produces
-files with names like `my_source_file.COVER.html`.  Therefore, the two
-tasks do not overwrite one another's output.
-
 You can override the `mix eunit --cover` output directory in your
 `mix.exs` file as described above.
 

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -51,8 +51,8 @@ defmodule Mix.Tasks.Eunit do
   @default_cover_opts [output: "cover", tool: Mix.Tasks.Test.Cover]
 
   def run(args) do
-    options = parse_options(args)
     project = Mix.Project.config
+    options = parse_options(args, project)
 
     # add test directory to compile paths and add
     # compiler options for test
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Eunit do
     analyze_coverage(cover_state)
   end
 
-  defp parse_options(args) do
+  defp parse_options(args, project) do
     {switches, argv} =
       OptionParser.parse!(args, strict: @switches, aliases: @aliases)
 
@@ -103,7 +103,9 @@ defmodule Mix.Tasks.Eunit do
                    _ -> []
                  end
 
-    switches
+    project[:eunit]
+    |> Keyword.take([:verbose, :profile, :cover, :start, :color])
+    |> Keyword.merge(switches)
     |> Keyword.put(:eunit_opts, eunit_opts)
     |> Keyword.put(:patterns, patterns)
   end

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -28,6 +28,7 @@ defmodule Mix.Tasks.Eunit do
   The following command line switch is also available:
 
   * --verbose/-v - Run eunit with the :verbose option.
+  * `--no-start` - do not start applications after compilation
 
   Test search path:
   -----------------
@@ -47,6 +48,10 @@ defmodule Mix.Tasks.Eunit do
     # make sure mix will let us run compile
     ensure_compile
     Mix.Task.run "compile"
+
+    # start the application
+    Mix.shell.print_app
+    Mix.Task.run "app.start", args
 
     # run the actual tests
     if(options[:cover], do: cover_start())

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -27,11 +27,35 @@ defmodule Mix.Tasks.Eunit do
 
   The following command line switches are also available:
 
-  * `--verbose`, `-v`   - Run eunit with the :verbose option.
-  * `--cover`, `-c`     - Create a coverage report after running the tests.
-  * `--profile`, `-p`   - Show a list of the 10 slowest tests.
-  * `--start`           - Start applications after compilation.
-  * `--no-color`        - Disable color output.
+  * `--verbose`, `-v` - run eunit with the :verbose option
+  * `--cover`, `-c` - create a coverage report after running the tests
+  * `--profile`, `-p` - show a list of the 10 slowest tests
+  * `--start` - start applications after compilation
+  * `--no-color` - disable color output
+  * `--force` - force compilation regardless of compilation times
+  * `--no-compile` - do not compile even if files require compilation
+  * `--no-archives-check` - do not check archives
+  * `--no-deps-check` - do not check dependencies
+  * `--no-elixir-version-check` - do not check Elixir version
+
+  The `verbose`, `cover`, `profile`, `start` and `color` switches can be set in
+  the `mix.exs` file and will apply to every invocation of this task. Switches
+  set on the command line will override any settings in the mixfile.
+
+  ```
+  def project do
+    [
+      # ...
+      eunit: [
+        verbose: false,
+        cover: true,
+        profile: true,
+        start: true,
+        color: false
+      ]
+    ]
+  end
+  ```
 
   Test search path:
   -----------------

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -30,8 +30,8 @@ defmodule Mix.Tasks.Eunit do
   * `--verbose`, `-v`   - Run eunit with the :verbose option.
   * `--cover`, `-c`     - Create a coverage report after running the tests.
   * `--profile`, `-p`   - Show a list of the 10 slowest tests.
+  * `--start`           - Start applications after compilation.
   * `--no-color`        - Disable color output.
-  * `--no-start`        - Do not start applications after compilation.
 
   Test search path:
   -----------------
@@ -59,13 +59,17 @@ defmodule Mix.Tasks.Eunit do
     post_config = eunit_post_config(project)
     modify_project_config(post_config)
 
-    # make sure mix will let us run compile
-    ensure_compile
-    Mix.Task.run "compile"
+    if Keyword.get(options, :compile, true) do
+      # make sure mix will let us run compile
+      ensure_compile
+      Mix.Task.run "compile", args
+    end
 
-    # start the application
-    Mix.shell.print_app
-    Mix.Task.run "app.start", args
+    if Keyword.get(options, :start, false) do
+      # start the application
+      Mix.shell.print_app
+      Mix.Task.run "app.start", args
+    end
 
     # start cover
     cover_state = start_cover_tool(options[:cover], project)

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -103,7 +103,7 @@ defmodule Mix.Tasks.Eunit do
                    _ -> []
                  end
 
-    project[:eunit]
+    project[:eunit] || []
     |> Keyword.take([:verbose, :profile, :cover, :start, :color])
     |> Keyword.merge(switches)
     |> Keyword.put(:eunit_opts, eunit_opts)

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -14,8 +14,7 @@ defmodule Mix.Tasks.Eunit do
   projects.
 
 
-  Command line options:
-  ---------------------
+  ## Command line options
 
   A list of patterns to match for test files can be supplied:
 
@@ -57,8 +56,7 @@ defmodule Mix.Tasks.Eunit do
   end
   ```
 
-  Test search path:
-  -----------------
+  ## Test search path
 
   All \".erl\" files in the src and test directories are considered.
 


### PR DESCRIPTION
This mimics the behavior of exunit and turns out to be really useful. If that behavior isn't what is wanted, it can be disabled by passing `--no-start`.
